### PR TITLE
added blockquote support (incl. nesting and colors)

### DIFF
--- a/src/components/MarkdownTextarea.tsx
+++ b/src/components/MarkdownTextarea.tsx
@@ -16,18 +16,6 @@ export const MarkdownTextarea = (props:MarkdownTextareaProps) => {
     );
 }
 
-/*const RecursiveBlockquote = (bqProps: {depth: number, color?: string, children: JSX.Element[]}) => {
-
-    if (bqProps.depth == 0) {
-        return bqProps.children;
-    }
-    return (<Blockquote p='sm' color={(bqProps.depth == 1 && bqProps.color) ? bqProps.color : bqDefaultColor}>
-        <RecursiveBlockquote depth={bqProps.depth - 1}
-                             color={bqProps.color}
-                             children={bqProps.children} />
-    </Blockquote>);
-}*/
-
 const processBlockquotes = (lines: Line[], rootKey: number): JSX.Element => {
     interface BQTreeNode {
         parent: BQTreeNode | null,


### PR DESCRIPTION
- added blockquotes which can be used with `> `
- blockquotes can be nested with `/>+ /`, i.e. `> `, `>> `, `>>> `, etc. (space mandatory.)
- a sequence of lines of the same depth (n. of `>`s) are grouped within the same blockquote
- colors can be used on blockquotes by ending a group with one of `{.is-danger}`, `{.is-warning}`, `{.is-success}`, `{.is-info}` (red, yellow, green, blue respectively)