### PR TITLE
cleanups to table and blockquote

### DIFF
--- a/src/components/MarkdownTextarea.tsx
+++ b/src/components/MarkdownTextarea.tsx
@@ -120,7 +120,7 @@ const processBlockquotes = (lines: Line[], rootKey: number): JSX.Element => {
 }
 
 const nextLinesOfType = (lines: Line[], type: LineType, startingAt: number) => {
-    let group: Line[] = [];
+    const group: Line[] = [];
     for (let i = startingAt; i < lines.length; i++) {
         if (lines[i].type == type) {
             group.push(lines[i])


### PR DESCRIPTION
- fixed off-by-one issues with groups of lines for table and blockquote
- fixed recognition of "header separator" row in tables (the second line which can optionally be the likes of `|---|--:|:--:|`)